### PR TITLE
canlib.py updates 1

### DIFF
--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -678,6 +678,17 @@ class canChannel(object):
         scale = c_long(scale)
         self.dll.canIoCtl(self.handle, canIOCTL_SET_TIMER_SCALE, byref(scale), 4)
 
+    def getChannelData(self):
+        self.canlib.fn = 'getChannelData'
+        return (
+            self.canlib.getChannelData_Name(self.index),
+            self.canlib.getChannelData_CardNumber(self.index),
+            self.canlib.getChannelData_EAN(self.index),
+            self.canlib.getChannelData_EAN_short(self.index),
+            self.canlib.getChannelData_Serial(self.index),
+            self.canlib.getChannelData_DriverName(self.index),
+            self.canlib.getChannelData_Firmware(self.index))
+
     def getChannelData_Name(self):
         self.canlib.fn = inspect.currentframe().f_code.co_name
         return self.canlib.getChannelData_Name(self.index)

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -279,7 +279,7 @@ class canlib(object):
         self.dll.canGetNumberOfChannels.argtypes = [POINTER(c_int)]
         self.dll.canGetNumberOfChannels.errcheck = self._canErrorCheck
 
-        self.dll.canGetChannelData.argtypes = [c_int, c_int, POINTER(None),
+        self.dll.canGetChannelData.argtypes = [c_int, c_int, c_void_p,
                                                c_size_t]
         self.dll.canGetChannelData.errcheck = self._canErrorCheck
 
@@ -326,22 +326,22 @@ class canlib(object):
                                               POINTER(c_uint)]
         self.dll.canTranslateBaud.errcheck = self._canErrorCheck
 
-        self.dll.canWrite.argtypes = [c_int, c_long, POINTER(None), c_uint,
+        self.dll.canWrite.argtypes = [c_int, c_long, c_void_p, c_uint,
                                       c_uint]
         self.dll.canWrite.errcheck = self._canErrorCheck
 
-        self.dll.canWriteWait.argtypes = [c_int, c_long, POINTER(None), c_uint,
+        self.dll.canWriteWait.argtypes = [c_int, c_long, c_void_p, c_uint,
                                           c_uint, c_ulong]
         self.dll.canWriteWait.errcheck = self._canErrorCheck
 
-        self.dll.canReadWait.argtypes = [c_int, POINTER(c_long), POINTER(None),
+        self.dll.canReadWait.argtypes = [c_int, POINTER(c_long), c_void_p,
                                          POINTER(c_uint), POINTER(c_uint),
                                          POINTER(c_ulong), c_ulong]
         self.dll.canReadWait.errcheck = self._canErrorCheck
 
         try:
             self.dll.canReadSpecificSkip.argtypes = [c_int, c_long,
-                                                     POINTER(None),
+                                                     c_void_p,
                                                      POINTER(c_uint),
                                                      POINTER(c_uint),
                                                      POINTER(c_ulong)]
@@ -353,17 +353,17 @@ class canlib(object):
             self.dll.canReadSyncSpecific.argtypes = [c_int, c_long, c_ulong]
             self.dll.canReadSyncSpecific.errcheck = self._canErrorCheck
         except Exception as e:
-            logging.debug(str(e) + ' (Not implemented in Linux)') 
+            logging.debug(str(e) + ' (Not implemented in Linux)')
 
         self.dll.canSetBusOutputControl.argtypes = [c_int, c_ulong]
         self.dll.canSetBusOutputControl.errcheck = self._canErrorCheck
 
-        self.dll.canIoCtl.argtypes = [c_int, c_uint, POINTER(None), c_uint]
+        self.dll.canIoCtl.argtypes = [c_int, c_uint, c_void_p, c_uint]
         self.dll.canIoCtl.errcheck = self._canErrorCheck
 
         try:
             self.dll.kvReadDeviceCustomerData.argtypes = [c_int, c_int, c_int,
-                                                          POINTER(None),
+                                                          c_void_p,
                                                           c_size_t]
             self.dll.kvReadDeviceCustomerData.errcheck = self._canErrorCheck
 

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from ctypes import *
 import sys
 import struct

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -673,6 +673,11 @@ class canChannel(object):
         self.canlib.fn = inspect.currentframe().f_code.co_name
         self.dll.canIoCtl(self.handle, canIOCTL_FLUSH_RX_BUFFER, None, 0)
 
+    def ioCtl_set_timer_scale(self, scale):
+        self.canlib.fn = 'ioCtl_set_timer_scale'
+        scale = c_long(scale)
+        self.dll.canIoCtl(self.handle, canIOCTL_SET_TIMER_SCALE, byref(scale), 4)
+
     def getChannelData_Name(self):
         self.canlib.fn = inspect.currentframe().f_code.co_name
         return self.canlib.getChannelData_Name(self.index)

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -346,13 +346,13 @@ class canlib(object):
                                                      POINTER(c_ulong)]
             self.dll.canReadSpecificSkip.errcheck = self._canErrorCheck
         except Exception as e:
-            print('Info:', e, '(Not implemented in Linux)')
+            logging.debug(str(e) + ' (Not implemented in Linux)')
 
         try:
             self.dll.canReadSyncSpecific.argtypes = [c_int, c_long, c_ulong]
             self.dll.canReadSyncSpecific.errcheck = self._canErrorCheck
         except Exception as e:
-            print('Info:', e, '(Not implemented in Linux)')
+            logging.debug(str(e) + ' (Not implemented in Linux)') 
 
         self.dll.canSetBusOutputControl.argtypes = [c_int, c_ulong]
         self.dll.canSetBusOutputControl.errcheck = self._canErrorCheck
@@ -429,7 +429,7 @@ class canlib(object):
             self.dll.kvDeviceGetMode.errcheck = self._canErrorCheck
 
         except Exception as e:
-            print('Info:', e, '(Not implemented in Linux)')
+            logging.debug(str(e) + ' (Not implemented in Linux)')
 
     def __del__(self):
         self.dll.canUnloadLibrary()

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -610,10 +610,20 @@ class canChannel(object):
     # so we use the name id_ instead
     def write(self, id_, msg, flag=0):
         self.canlib.fn = 'write'
+        if not isinstance(msg, (bytes, str)):
+            if not isinstance(msg, bytearray):
+                msg = bytearray(msg)
+            msg = bytes(msg)
+
         self.dll.canWrite(self.handle, id_, msg, len(msg), flag)
 
     def writeWait(self, id_, msg, flag=0, timeout=0):
         self.canlib.fn = inspect.currentframe().f_code.co_name
+        if not isinstance(msg, (bytes, str)):
+            if not isinstance(msg, bytearray):
+                msg = bytearray(msg)
+            msg = bytes(msg)
+
         self.dll.canWriteWait(self.handle, id_, msg, len(msg), flag, timeout)
 
     def read(self, timeout=0):
@@ -637,7 +647,7 @@ class canChannel(object):
         flag = c_uint()
         time = c_ulong()
         self.dll.canReadWait(self.handle, id_, msg, dlc, flag, time, timeout)
-        return id_.value, msg[:dlc.value], dlc.value, flag.value, time.value
+        return id_.value, bytearray(msg.raw[:dlc.value]), dlc.value, flag.value, time.value
 
     def readDeviceCustomerData(self, userNumber=100, itemNumber=0):
         self.fn = inspect.currentframe().f_code.co_name

--- a/Samples/Python/canlib.py
+++ b/Samples/Python/canlib.py
@@ -641,25 +641,23 @@ class canChannel(object):
 
     def readDeviceCustomerData(self, userNumber=100, itemNumber=0):
         self.fn = inspect.currentframe().f_code.co_name
-        buf_type = c_uint8 * 8
-        buf = buf_type()
+        buf = create_string_buffer(8)
         user = c_int(userNumber)
         item = c_int(itemNumber)
-        self.dll.kvReadDeviceCustomerData(self.handle, user, item, byref(buf),
+        self.dll.kvReadDeviceCustomerData(self.handle, user, item, buf,
                                           sizeof(buf))
         return struct.unpack('!Q', buf)[0]
 
     def readSpecificSkip(self, id_, timeout=0):
         self.canlib.fn = inspect.currentframe().f_code.co_name
-        msg = self.canlib.canMessage()
+        msg = create_string_buf(8)
         id_ = c_long(id_)
         dlc = c_uint()
         flag = c_uint()
-        time = c_ulong(timeout)
-        self.dll.canReadSpecificSkip(self.handle, id_, byref(msg), byref(dlc),
-                                     byref(flag), byref(time))
-        msgList = [msg[i] for i in range(len(msg))]
-        return id_.value, msgList[:dlc.value], dlc.value, flag.value, time.value
+        time = c_ulong(timeout)  # Is this really right? 
+        self.dll.canReadSpecificSkip(self.handle, id_, msg, dlc, flag, time)
+        # Why is id_ returned here? It is a constant.
+        return id_.value, msg[:dlc.value], dlc.value, flag.value, time.value
 
     def readSyncSpecific(self, id_, timeout=0):
         self.canlib.fn = inspect.currentframe().f_code.co_name


### PR DESCRIPTION
Greetings,

I had some email correspondence with Magnus Carlsson in early August via support@kv....

I don't necessarily expect this pull request to be applied, but it is a convenient way of showing you my ideas.

The main significant change is "Convert read,...."
I think that read (and write) should work with str (or bytes or bytearray) type rather than list or tuple.
This is how the read method works for file-like objects (file, Serial etc), and it is more convenient for use with struct.pack/unpack for manipulating the contents of the message payload.

You'll see I removed some byref(),  they aren't required when the argtypes have been declared as pointers.

I added ioCtl_set_timer_scale because I needed it in my application.

regards

Eliot Blennerhassett
